### PR TITLE
Preserve line endings

### DIFF
--- a/RelaseNotes.md
+++ b/RelaseNotes.md
@@ -1,3 +1,6 @@
+[Next]
+- The codefix suggestion will use the same line ending as the offending code.
+
 1.15
 - Default severity of analyzers should be warning to be suppressable.
 

--- a/src/Nullable.Extended.Analyzer/Nullable.Extended.Analyzer.Test/NullForgivingCodeFixProviderTests.cs
+++ b/src/Nullable.Extended.Analyzer/Nullable.Extended.Analyzer.Test/NullForgivingCodeFixProviderTests.cs
@@ -12,7 +12,8 @@ namespace Nullable.Extended.Analyzer.Test
     public class NullForgivingCodeFixProviderTests
     {
         [TestMethod]
-        public async Task CommentIsAddedToBareItem()
+        [DataRow("\n"), DataRow("\r\n")]
+        public async Task CommentIsAddedToBareItem(string lineEnding)
         {
             const string source = """
             class C {
@@ -38,11 +39,12 @@ namespace Nullable.Extended.Analyzer.Test
                 DiagnosticResult.CompilerWarning(NullForgivingDetectionAnalyzer.GeneralDiagnosticId).WithLocation(0)
             };
 
-            await VerifyCodeFixAsync(source, expected, fixedSource);
+            await VerifyCodeFixAsync(source.ReplaceLineEndings(lineEnding), expected, fixedSource.ReplaceLineEndings(lineEnding));
         }
 
         [TestMethod]
-        public async Task CommentIsAddedToItemThatAlreadyHasAComment()
+        [DataRow("\n"), DataRow("\r\n")]
+        public async Task CommentIsAddedToItemThatAlreadyHasAComment(string lineEnding)
         {
             const string source = """
             class C {
@@ -70,7 +72,7 @@ namespace Nullable.Extended.Analyzer.Test
                 DiagnosticResult.CompilerWarning(NullForgivingDetectionAnalyzer.GeneralDiagnosticId).WithLocation(0)
             };
 
-            await VerifyCodeFixAsync(source, expected, fixedSource);
+            await VerifyCodeFixAsync(source.ReplaceLineEndings(lineEnding), expected, fixedSource.ReplaceLineEndings(lineEnding));
         }
     }
 }

--- a/src/Nullable.Extended.Analyzer/Nullable.Extended.Analyzer/NullForgivingDetectionAnalyzerCodeFixProvider.cs
+++ b/src/Nullable.Extended.Analyzer/Nullable.Extended.Analyzer/NullForgivingDetectionAnalyzerCodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace Nullable.Extended.Analyzer
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(NullForgivingDetectionAnalyzerCodeFixProvider)), Shared]
     public class NullForgivingDetectionAnalyzerCodeFixProvider : CodeFixProvider
     {
-        private const string CodeFixPlaceholderText = Justification.SuppressionCommentPrefix + "TODO:\r\n";
+        private const string CodeFixPlaceholderText = Justification.SuppressionCommentPrefix + "TODO:";
         private const string CodeFixTitle = "Suppress with comment";
 
         private static readonly SyntaxTriviaList CodeFixPlaceholderTrivia = CSharpSyntaxTree.ParseText(CodeFixPlaceholderText).GetRoot().GetLeadingTrivia();
@@ -51,7 +51,12 @@ namespace Nullable.Extended.Analyzer
             var leadingTrivia = targetNode.GetLeadingTrivia();
             var indent = leadingTrivia.LastOrDefault(item => item.IsKind(SyntaxKind.WhitespaceTrivia));
 
-            leadingTrivia = leadingTrivia.AddRange(CodeFixPlaceholderTrivia);
+            var newline = leadingTrivia.FirstOrDefault(trivia => trivia.IsKind(SyntaxKind.EndOfLineTrivia));
+            newline = targetNode.GetTrailingTrivia().FirstOrDefault(trivia => trivia.IsKind(SyntaxKind.EndOfLineTrivia));
+            if (Equals(newline, default(SyntaxTrivia)))
+                newline = SyntaxFactory.CarriageReturnLineFeed;
+
+            leadingTrivia = leadingTrivia.AddRange(CodeFixPlaceholderTrivia.Add(newline));
 
             if (indent != null)
             {


### PR DESCRIPTION
I had a test fail due to my git settings normalizing line endings, which led to find a hard-coded CRLF. Confirming that it did indeed insert a CRLF into an otherwise LF-only file, I found it easy enough to submit a fix:

I sniff the line ending of the `CSharpSyntaxNode` and use that for the injected line. If it can't find one for some reason, I chose to fall back to CRLF, as that's what it was doing before.

I've expanded the tests to cover both LF AND CRLF.