### PR TITLE
Fix crash when suggested codefix for top level statements

### DIFF
--- a/src/Nullable.Extended.Analyzer/Nullable.Extended.Analyzer.Test/NullForgivingCodeFixProviderTests.cs
+++ b/src/Nullable.Extended.Analyzer/Nullable.Extended.Analyzer.Test/NullForgivingCodeFixProviderTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.Testing;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using static Nullable.Extended.Analyzer.Test.Verifiers.CSharpCodeFixVerifier<
@@ -71,6 +72,26 @@ namespace Nullable.Extended.Analyzer.Test
             };
 
             await VerifyCodeFixAsync(source, expected, fixedSource);
+        }
+
+        [TestMethod]
+        public async Task CommentIsAddedToTopLevelStatement()
+        {
+            const string source = """
+            System.Console.WriteLine("Hello, World!".ToString(){|#0:!|});
+            """;
+
+            const string fixedSource = """
+            // ! TODO:
+            System.Console.WriteLine("Hello, World!".ToString()!);
+            """;
+
+            var expected = new[]
+            {
+                DiagnosticResult.CompilerWarning(NullForgivingDetectionAnalyzer.GeneralDiagnosticId).WithLocation(0)
+            };
+
+            await VerifyCodeFixAsync(source, expected, fixedSource, outputKind: OutputKind.ConsoleApplication);
         }
     }
 }

--- a/src/Nullable.Extended.Analyzer/Nullable.Extended.Analyzer.Test/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/src/Nullable.Extended.Analyzer/Nullable.Extended.Analyzer.Test/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -41,10 +41,11 @@ namespace Nullable.Extended.Analyzer.Test.Verifiers
             => await VerifyCodeFixAsync(source, new[] { expected }, fixedSource, referenceAssemblies);
 
         /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult[], string)"/>
-        public static async Task VerifyCodeFixAsync(string source, IEnumerable<DiagnosticResult> expected, string? fixedSource, ReferenceAssemblies? referenceAssemblies = null)
+        public static async Task VerifyCodeFixAsync(string source, IEnumerable<DiagnosticResult> expected, string? fixedSource, ReferenceAssemblies? referenceAssemblies = null, OutputKind? outputKind = null)
         {
             var test = new Test(source, fixedSource, referenceAssemblies);
-
+            if (outputKind is not null)
+                test.TestState.OutputKind = outputKind;
             test.ExpectedDiagnostics.AddRange(expected);
             await test.RunAsync(CancellationToken.None);
         }

--- a/src/Nullable.Extended.Analyzer/Nullable.Extended.Analyzer/NullForgivingDetectionAnalyzerCodeFixProvider.cs
+++ b/src/Nullable.Extended.Analyzer/Nullable.Extended.Analyzer/NullForgivingDetectionAnalyzerCodeFixProvider.cs
@@ -53,7 +53,7 @@ namespace Nullable.Extended.Analyzer
 
             leadingTrivia = leadingTrivia.AddRange(CodeFixPlaceholderTrivia);
 
-            if (indent != null)
+            if (indent != default(SyntaxTrivia))
             {
                 leadingTrivia = leadingTrivia.Add(indent);
             }


### PR DESCRIPTION
This should fix #18.